### PR TITLE
Fix parsing of negative numbers with Tuba.

### DIFF
--- a/SL.xs
+++ b/SL.xs
@@ -886,11 +886,12 @@ convert_to_tuba_cbt(struct jsonsl_state_st *state)
     }
     if (state->special_flags & JSONSL_SPECIALf_BOOLEAN) {
         return PLTUBA_CALLBACK_BOOLEAN;
-    } else if (state->special_flags & JSONSL_SPECIALf_NUMERIC) {
+    } else if (state->special_flags & (JSONSL_SPECIALf_NUMERIC | JSONSL_SPECIALf_DASH)) {
         return PLTUBA_CALLBACK_NUMBER;
     } else if (state->special_flags == JSONSL_SPECIALf_NULL) {
         return PLTUBA_CALLBACK_NULL;
     }
+    warn("Special flag is %d", state->special_flags);
     die("wtf?");
     return 0;
 }

--- a/eg/tuba.pl
+++ b/eg/tuba.pl
@@ -30,6 +30,7 @@ $JSON ||= <<'EOJ';
     "c" : { "d" : "e" },
     "f" : [ "g", "h", "i", "j" ],
     "a number" : 0.4444444444,
+    "a negative number" : -44,
     "a (false) boolean": false,
     "another (true) boolean" : true,
     "a null value" : null,

--- a/t/41-tuba_accum_all.t
+++ b/t/41-tuba_accum_all.t
@@ -108,6 +108,14 @@ my $ExpResults =
   ],
   [
     {
+      Key => "a negative number",
+      Mode => ">",
+      Type => "="
+    },
+    "-44"
+  ],
+  [
+    {
       Key => "a (false) boolean",
       Mode => ">",
       Type => "?"
@@ -166,6 +174,7 @@ my $JSON ||= <<'EOJ';
     "c" : { "d" : "e" },
     "f" : [ "g", "h", "i", "j" ],
     "a number" : 0.4444444444,
+    "a negative number" : -44,
     "a (false) boolean": false,
     "another (true) boolean" : true,
     "a null value" : null,


### PR DESCRIPTION
Jsonsl passes leading dash as its own event which is not handled by Tuba's `convert_to_tuba_cbt` and hence dies with "wtf?". Instead, let dash be handled by number callback.